### PR TITLE
Issue #54 - Addition of support for sending binary data (Android only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The plugin creates a "Socket" object exposed on window.tlantic.plugins.socket. T
 * connect: opens a socket connection;
 * disconnect: closes a socket connection;
 * disconnectAll: closes ALL opened connections;
-* send: send data using a given connection;
+* send: send text data using a given connection;
+* sendBinary: send binary data using a given connection;
 * isConnected: returns a boolean falg representing socket connectivity status;
 * receive: callback used by plugin's native code. Can be override by a custom implementation.
 
@@ -90,7 +91,7 @@ window.tlantic.plugins.socket.connect(
 
 ### send (successCallback, errorCallback, connectionId, data)
 
-Sends information and calls success callback if information was send and does not wait for any response. To check how to receive data, please see the item below.
+Sends text information and calls success callback if information was sent and does not wait for any response. To check how to receive data, please see the item below.
 
 Example:
 
@@ -108,7 +109,29 @@ window.tlantic.plugins.socket.send(
 );
 ```
 
-### isConnected (connectionId, successCallback, errorCallback)
+### sendBinary (successCallback, errorCallback, connectionId, data)
+
+Sends binary data and calls success callback if information was sent and does not wait for any response. To check how to receive data, please see the item below.
+
+Binary data to be sent is passed in `data` which is a JSONArray, one integer element per byte.
+
+Example:
+
+```
+window.tlantic.plugins.socket.sendBinary(
+  function () {
+    console.log('worked!');  
+  },
+  
+  function () {
+    console.log('failed!');
+  },
+  '192.168.2.5:18002',
+  [ 0x00, 0x01, 0x00, 0xFD ]
+);
+```
+
+#### isConnected (connectionId, successCallback, errorCallback)
 
 Returns a boolean value representing the connection status. True, if socket streams are opened and false case else.
 Both values are supposed to be returned through successCallback. The error callback is called only when facing errors due the check process.

--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -3,6 +3,7 @@ package com.tlantic.plugins.socket;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.UnknownHostException;
@@ -19,6 +20,7 @@ public class Connection extends Thread {
 
 	private Socket callbackSocket;
 	private PrintWriter writer;
+	private OutputStream outputStream;
 	private BufferedReader reader;
 
 	private Boolean mustClose;
@@ -101,6 +103,17 @@ public class Connection extends Thread {
 
 
 
+	/**
+	 * Outputs to socket output stream to send binary data to target host.
+	 * 
+	 * @param data information to be sent
+	 */
+	public void writeBinary(byte[] data) throws IOException {
+		this.outputStream.write(data);
+	}
+
+
+
 	/* (non-Javadoc)
 	 * @see java.lang.Thread#run()
 	 */
@@ -111,6 +124,7 @@ public class Connection extends Thread {
 		try {
 			this.callbackSocket = new Socket(this.host, this.port);
 			this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);
+			this.outputStream = this.callbackSocket.getOutputStream();
 			this.reader = new BufferedReader(new InputStreamReader(callbackSocket.getInputStream()));
 
 			// receiving data chunk

--- a/www/socket.js
+++ b/www/socket.js
@@ -39,6 +39,12 @@ Socket.prototype.send = function (successCallback, errorCallback, connectionId, 
     exec(successCallback, errorCallback, this.pluginRef, 'send', [connectionId, typeof data == 'string' ? data : JSON.stringify(data)]);
 };
 
+///
+Socket.prototype.sendBinary = function (successCallback, errorCallback, connectionId, data) {
+    'use strict';
+    exec(successCallback, errorCallback, this.pluginRef, 'sendBinary', [connectionId, data]);
+};
+
 //
 Socket.prototype.receive = function (host, port, connectionId, chunk) {
     'use strict';


### PR DESCRIPTION
This is a submission for inclusion to resolve issue #54.

It also provides and interface for issue #53, but no implementation for any platform other than Android.

I've added a new function, sendBinary, as I proposed in issue #54, and documented this in README.md.

I have done basic sanity testing, and it works, but I haven't tested all exception cases.
