### PR TITLE
(Android only) Fixes for a few problems and better callbacks

### DIFF
--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -149,13 +149,11 @@ public class Connection extends Thread {
 
 		// creating connection
 		try {
-            Log.d("connection", "Initiating connection to socket");
             //This is a bad practice. should be using handlers to send this to SocketPlugin
 			this.callbackSocket = new Socket();
             this.callbackSocket.connect(new InetSocketAddress(this.host, this.port), 20000);
             this.hook.sendConnectedEvent(this.buildKey, this.host, this.port, this);
             this.callbackContext.success(this.buildKey);
-            Log.d("connection", "Connected to socket");
             this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);
 			this.reader = new BufferedReader(new InputStreamReader(callbackSocket.getInputStream()));
 
@@ -165,7 +163,6 @@ public class Connection extends Thread {
 				try {
 
 					if (this.isConnected()) {
-                        Log.d("connection", "reading......");
 						chunk = reader.readLine();
 
 						if (chunk != null) {
@@ -175,8 +172,6 @@ public class Connection extends Thread {
 						}
 					}
 				} catch (Exception e) {
-                    Log.d("connection", "connection closed");
-
                     try {
                         this.callbackSocket.close();
                     } catch (Exception closeException) {
@@ -191,16 +186,13 @@ public class Connection extends Thread {
 		} catch (UnknownHostException e1) {
 			// TODO Auto-generated catch block
             this.callbackContext.error(this.buildKey+" did not connect: unknown host");
-            Log.d("connection", "unknown host exception raised on connection");
 			e1.printStackTrace();
 		} catch (IOException e1) {
 			// TODO Auto-generated catch block
             this.callbackContext.error(this.buildKey+" did not connect: io host");
-            Log.d("connection", "io exception raised on connection");
 			e1.printStackTrace();
 		} catch (Exception el) {
             this.callbackContext.error(this.buildKey+" did not connect: unknown error");
-            Log.d("connection", "exception raised on connection");
             el.printStackTrace();
         }
 

--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -133,8 +133,10 @@ public class Connection extends Thread {
 	 * 
 	 * @param data information to be sent
 	 */
-	public void write(String data) {
+	public boolean write(String data) {
 		this.writer.println(data);
+        this.writer.flush();
+        return !this.writer.checkError();
 	}
 
 

--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -149,13 +149,13 @@ public class Connection extends Thread {
 
 		// creating connection
 		try {
-            Log.d("now", "Initiating connection to socket");
+            Log.d("connection", "Initiating connection to socket");
             //This is a bad practice. should be using handlers to send this to SocketPlugin
 			this.callbackSocket = new Socket();
             this.callbackSocket.connect(new InetSocketAddress(this.host, this.port), 20000);
             this.hook.sendConnectedEvent(this.buildKey, this.host, this.port, this);
             this.callbackContext.success(this.buildKey);
-            Log.d("now", "Connected to socket");
+            Log.d("connection", "Connected to socket");
             this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);
 			this.reader = new BufferedReader(new InputStreamReader(callbackSocket.getInputStream()));
 
@@ -165,7 +165,7 @@ public class Connection extends Thread {
 				try {
 
 					if (this.isConnected()) {
-                        Log.d("now", "reading......");
+                        Log.d("connection", "reading......");
 						chunk = reader.readLine();
 
 						if (chunk != null) {
@@ -173,14 +173,9 @@ public class Connection extends Thread {
 							System.out.print("## RECEIVED DATA: " + chunk);
 							hook.sendMessage(this.host, this.port, chunk);
 						}
-					} else {
-                        Log.d("now", "Connection closed but still running");
-                    }
+					}
 				} catch (Exception e) {
-                    //Only socket exception gets triggerred frequently
-                    //TODO close the socket
-                    //TODO this.mustClose = true
-                    Log.d("now", "connection closed");
+                    Log.d("connection", "connection closed");
 
                     try {
                         this.callbackSocket.close();
@@ -196,16 +191,16 @@ public class Connection extends Thread {
 		} catch (UnknownHostException e1) {
 			// TODO Auto-generated catch block
             this.callbackContext.error(this.buildKey+" did not connect: unknown host");
-            Log.d("now", "unknown host exception raised on connection");
+            Log.d("connection", "unknown host exception raised on connection");
 			e1.printStackTrace();
 		} catch (IOException e1) {
 			// TODO Auto-generated catch block
             this.callbackContext.error(this.buildKey+" did not connect: io host");
-            Log.d("now", "io exception raised on connection");
+            Log.d("connection", "io exception raised on connection");
 			e1.printStackTrace();
 		} catch (Exception el) {
             this.callbackContext.error(this.buildKey+" did not connect: unknown error");
-            Log.d("now", "exception raised on connection");
+            Log.d("connection", "exception raised on connection");
             el.printStackTrace();
         }
 

--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -148,8 +148,10 @@ public class Connection extends Thread {
 		// creating connection
 		try {
             Log.d("now", "Initiating connection to socket");
+            //This is a bad practice. should be using handlers to send this to SocketPlugin
 			this.callbackSocket = new Socket();
             this.callbackSocket.connect(new InetSocketAddress(this.host, this.port), 20000);
+            this.hook.sendConnectedEvent(this.buildKey, this.host, this.port, this);
             this.callbackContext.success(this.buildKey);
             Log.d("now", "Connected to socket");
             this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);

--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -1,11 +1,18 @@
 package com.tlantic.plugins.socket;
 
+import android.util.Log;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.lang.Exception;
+import java.lang.String;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import org.apache.cordova.CallbackContext;
 
 
 /**
@@ -24,7 +31,24 @@ public class Connection extends Thread {
 	private Boolean mustClose;
 	private String host;
 	private int port;
+    private CallbackContext callbackContext;
+    private String buildKey;
 
+    public String getBuildKey() {
+        return buildKey;
+    }
+
+    public void setBuildKey(String buildKey) {
+        this.buildKey = buildKey;
+    }
+
+    public CallbackContext getCallbackContext() {
+        return callbackContext;
+    }
+
+    public void setCallbackContext(CallbackContext callbackContext) {
+        this.callbackContext = callbackContext;
+    }
 
 	/**
 	 * Creates a TCP socket connection object.
@@ -42,6 +66,20 @@ public class Connection extends Thread {
 		this.port = port;
 		this.hook = pool;
 	}
+
+    /**
+     * Creates a TCP socket connection object.
+     *
+     * @param pool Object containing "sendMessage" method to be called as a callback for data receive.
+     * @param host Target host for socket connection.
+     * @param port Target port for socket connection
+     * @param callbackContext for sending callbacks
+     */
+    public Connection(SocketPlugin pool, String host, int port, CallbackContext callbackContext, String buildKey) {
+        this(pool, host, port);
+        this.callbackContext = callbackContext;
+        this.buildKey = buildKey;
+    }
 
 
 	/**
@@ -109,8 +147,10 @@ public class Connection extends Thread {
 
 		// creating connection
 		try {
-			this.callbackSocket = new Socket(this.host, this.port);
-			this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);
+			this.callbackSocket = new Socket();
+            this.callbackSocket.connect(new InetSocketAddress(this.host, this.port), 20000);
+            this.callbackContext.success(this.buildKey);
+            this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);
 			this.reader = new BufferedReader(new InputStreamReader(callbackSocket.getInputStream()));
 
 			// receiving data chunk
@@ -126,7 +166,9 @@ public class Connection extends Thread {
 							System.out.print("## RECEIVED DATA: " + chunk);
 							hook.sendMessage(this.host, this.port, chunk);
 						}
-					}
+					} else {
+						
+                    			}
 				} catch (Exception e) {
 					e.printStackTrace();
 				}
@@ -134,11 +176,16 @@ public class Connection extends Thread {
 
 		} catch (UnknownHostException e1) {
 			// TODO Auto-generated catch block
+            		this.callbackContext.error(this.buildKey+" did not connect: unknown host");
 			e1.printStackTrace();
 		} catch (IOException e1) {
 			// TODO Auto-generated catch block
+            		this.callbackContext.error(this.buildKey+" did not connect: io host");
 			e1.printStackTrace();
-		}
+		} catch (Exception el) {
+		        this.callbackContext.error(this.buildKey+" did not connect: unknown error");
+            		el.printStackTrace();
+        	}
 
 	}
 

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -223,6 +223,9 @@ public class SocketPlugin extends CordovaPlugin {
 					
 					// removing from pool
 					pool.remove(key);
+
+                    //Triggering event
+                    this.sendDisconnectedEvent(key);
 				}
 
 				// ending with success
@@ -256,6 +259,9 @@ public class SocketPlugin extends CordovaPlugin {
 			
 			// removing from pool
 			this.pool.remove(pairs.getKey());
+
+            //Triggering event
+            this.sendDisconnectedEvent(pairs.getKey());
 		}
 		
 		callbackContext.success("All connections were closed.");

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -31,7 +31,6 @@ public class SocketPlugin extends CordovaPlugin {
 	@Override
 	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
 
-		System.out.println("Skandha");
 		if (action.equals("connect")) {
 			this.connect(args, callbackContext);
 			return true;
@@ -92,7 +91,7 @@ public class SocketPlugin extends CordovaPlugin {
 				// preparing parameters
 				host = args.getString(0);
 				port = args.getInt(1);
-				System.out.println("trying to connect to host: "+host+", "+port);
+				Log.d("connection", "trying to connect to host: "+host+", "+port);
 				key = this.buildKey(host, port);
 
 				// creating connection

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -91,7 +91,6 @@ public class SocketPlugin extends CordovaPlugin {
 				// preparing parameters
 				host = args.getString(0);
 				port = args.getInt(1);
-				Log.d("connection", "trying to connect to host: "+host+", "+port);
 				key = this.buildKey(host, port);
 
 				// creating connection

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -99,7 +99,6 @@ public class SocketPlugin extends CordovaPlugin {
 				if (this.pool.get(key) == null) {
 					socket = new Connection(this, host, port, callbackContext, key);
 					socket.start();
-					this.pool.put(key, socket);
 				}
 
 				// adding to pool
@@ -294,5 +293,11 @@ public class SocketPlugin extends CordovaPlugin {
         pool.remove(buildKey);
 
         this.sendEvent(receiveHook);
+    }
+
+    public synchronized void sendConnectedEvent (String key, String ip, int port, Connection socket) {
+        this.pool.put(key, socket);
+
+        //TODO trigger an event later when needed
     }
 }

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -95,13 +95,13 @@ public class SocketPlugin extends CordovaPlugin {
 
 				// creating connection
 				if (this.pool.get(key) == null) {
-					socket = new Connection(this, host, port);
+					socket = new Connection(this, host, port, callbackContext, key);
 					socket.start();
 					this.pool.put(key, socket);
 				}
 
 				// adding to pool
-				callbackContext.success(key);
+//				callbackContext.success(key);
 
 			} catch (JSONException e) {
 				callbackContext.error("Invalid parameters for 'connect' action: " + e.getMessage());
@@ -282,5 +282,4 @@ public class SocketPlugin extends CordovaPlugin {
 			
 		});
 	}
-	
 }

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -181,10 +181,10 @@ public class SocketPlugin extends CordovaPlugin {
 				} else {
 				
 					// write on output stream
-					socket.write(data);
-					
-					// ending send process
-					callbackContext.success();	
+					if(socket.write(data))
+                        callbackContext.success();
+                    else
+                        callbackContext.error("Failed to send data");
 				}
 								
 			} catch (JSONException e) {

--- a/www/socket.js
+++ b/www/socket.js
@@ -6,6 +6,7 @@ function Socket(){
     'use strict';
 
     this.receiveHookName = 'SOCKET_RECEIVE_DATA_HOOK';      // *** Event name to act as "hook" for data receiving
+    this.disconnectedHookName = 'SOCKET_DISCONNECTED';
     this.pluginRef = 'Socket';                              // *** Plugin reference for Cordova.exec calls
 }
 
@@ -57,4 +58,18 @@ Socket.prototype.receive = function (host, port, connectionId, chunk) {
 
     document.dispatchEvent(evReceive);
 };
+
+Socket.prototype.disconnectedEvent = function(connectionId) {
+    var evReceive = document.createEvent('Events');
+
+    evReceive.initEvent(this.disconnectedHookName, true, true);
+    evReceive.metadata = {
+        connection: {
+            id: connectionId
+        }
+    };
+
+    document.dispatchEvent(evReceive);
+};
+
 module.exports = new Socket();


### PR DESCRIPTION
Change list (Only for android):
1. Closing thread when a connection is terminated
2. Look for connection termination and throw an event to the frontend
3. accurate callbacks - connect success callback is called after actual connection and failure callback is called if the connection fails
4. isConnected keeps a better track of the connections
